### PR TITLE
51 check romfiles exist

### DIFF
--- a/sksurgerynditracker/nditracker.py
+++ b/sksurgerynditracker/nditracker.py
@@ -277,6 +277,8 @@ class NDITracker(SKSBaseTracker):
             raise KeyError("Configuration for vega and polaris must"
                            "contain a list of 'romfiles'")
         for romfile in configuration.get("romfiles"):
+            if not os.path.exists(romfile):
+                raise FileNotFoundError(f"ROM file '{romfile}' not found.")
             self._tool_descriptors.append({"description" : romfile})
 
     def _check_config_polaris(self, configuration):
@@ -287,6 +289,8 @@ class NDITracker(SKSBaseTracker):
             raise KeyError("Configuration for vega and polaris must"
                            "contain a list of 'romfiles'")
         for romfile in configuration.get("romfiles"):
+            if not os.path.exists(romfile):
+                raise FileNotFoundError(f"ROM file '{romfile}' not found.")
             self._tool_descriptors.append({"description" : romfile})
 
     def _check_config_dummy(self, configuration):
@@ -295,6 +299,8 @@ class NDITracker(SKSBaseTracker):
         """
         if "romfiles" in configuration:
             for romfile in configuration.get("romfiles"):
+                if not os.path.exists(romfile):
+                    raise FileNotFoundError(f"ROM file '{romfile}' not found.")
                 self._tool_descriptors.append({"description" : romfile})
 
     def close(self):


### PR DESCRIPTION
While validating camera configurations, use `os.path.exists` to ensure that each path in `romfiles` exists. If any path is invalid, then raise a `FileNotFoundError`. Fixes Issue #51.