### PR TITLE
Change error messages when connecting to a vicra device over serial to accurately reflect what went wrong.

### DIFF
--- a/sksurgerynditracker/nditracker.py
+++ b/sksurgerynditracker/nditracker.py
@@ -74,7 +74,8 @@ def _get_serial_port_name(configuration):
                       " Result: ", result, file=fileout)
                 if result == ndicapy.NDI_OKAY:
                     break
-        else:
+            else:
+                # If we did not break from the for loop:
                 raise IOError('Could not find any NDI device in '
                     f'{ports_to_probe} serial port candidates checked. '
                     + SERIAL_CONNECTION_ERRMSG)
@@ -88,7 +89,7 @@ def _get_serial_port_name(configuration):
                           " Result: ", result, file=fileout)
                 else:
                     raise IOError(f'Could not connect to serial port {serial_port} '
-                        f'as there are only {len(serial_ports)} ports available'
+                        f'as there are only {len(serial_ports)} ports available.'
                         + SERIAL_CONNECTION_ERRMSG)
 
             if isinstance(serial_port, str):
@@ -96,6 +97,7 @@ def _get_serial_port_name(configuration):
                 result = ndicapy.ndiProbe(name)
                 print("Probing port: ", name,
                       " Result: ", result, file=fileout)
+                    
             if result != ndicapy.NDI_OKAY:
                 raise IOError(f'Could not connect to an NDI device on the chosen port, {serial_port}.'
                     + SERIAL_CONNECTION_ERRMSG)

--- a/sksurgerynditracker/nditracker.py
+++ b/sksurgerynditracker/nditracker.py
@@ -18,15 +18,6 @@ import ndicapy
 from sksurgerynditracker.serial_utils.com_ports import \
         fix_com_port_greater_than_9
 
-SERIAL_CONNECTION_ERRMSG = """
-Please check the following:\n
-\t1) Is an NDI device connected to your computer?\n
-\t2) Is the NDI device switched on?\n
-\t3) Do you have sufficient privilege to connect to
-the device? (e.g. on Linux are you part of the "dialout"
-group?)'
-"""
-
 @contextlib.contextmanager
 def _open_logging(verbose):
     """
@@ -55,6 +46,15 @@ def _get_serial_port_name(configuration):
     :raises: IOError if port not found or port probe fails
     """
 
+    serial_connection_errmsg = """
+    Please check the following:\n
+    \t1) Is an NDI device connected to your computer?\n
+    \t2) Is the NDI device switched on?\n
+    \t3) Do you have sufficient privilege to connect to
+    the device? (e.g. on Linux are you part of the "dialout"
+    group?)'
+    """
+
     with _open_logging(configuration.get('verbose', False)) as fileout:
         serial_port = configuration.get("serial port", None)
         ports_to_probe = configuration.get("ports to probe", 20)
@@ -78,7 +78,7 @@ def _get_serial_port_name(configuration):
                 # If we did not break from the for loop:
                 raise IOError('Could not find any NDI device in '
                     f'{ports_to_probe} serial port candidates checked. '
-                    + SERIAL_CONNECTION_ERRMSG)
+                    + serial_connection_errmsg)
 
         else:
             if isinstance(serial_port, int):
@@ -90,7 +90,7 @@ def _get_serial_port_name(configuration):
                 else:
                     raise IOError(f'Could not connect to serial port {serial_port} '
                         f'as there are only {len(serial_ports)} ports available.'
-                        + SERIAL_CONNECTION_ERRMSG)
+                        + serial_connection_errmsg)
 
             if isinstance(serial_port, str):
                 name = serial_port
@@ -100,7 +100,7 @@ def _get_serial_port_name(configuration):
                     
             if result != ndicapy.NDI_OKAY:
                 raise IOError(f'Could not connect to an NDI device on the chosen port, {serial_port}.'
-                    + SERIAL_CONNECTION_ERRMSG)
+                    + serial_connection_errmsg)
         return name
 
 


### PR DESCRIPTION
Previously, the error message printed "Tried 10 devices" (for example) even if only trying to connect to 1 named serial port. This fixes the incorrect error messages and adds new error messages for the different cases.